### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Stream variables beetween 2 JavaScript threads (client/server, ipc, worker/main thread).",
   "version": "0.3.2",
   "author": "Nicolas Froidure",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/nfroidure/VarStream.git"


### PR DESCRIPTION
We use license finder internally to check npm dependencies licenses against an approved list. This fails without an explicit allow if a license property is not added to package.json.