### PR TITLE
Updated README.md to reflect the license correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,4 @@ npm test
 * Nicolas Froidure - @nfroidure
 
 ## License
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>
+This program is licensed under the MIT license. See the [LICENSE](./LICENSE) file for more details.


### PR DESCRIPTION
package.json and LICENSE both specify the MIT license, yet the README doesn't seem up-to-date with that.
Can we fix this?